### PR TITLE
Resolve with anonymous classes

### DIFF
--- a/UrlTemplates/Expression.cs
+++ b/UrlTemplates/Expression.cs
@@ -183,7 +183,7 @@
 
                     if (dictionaryValue == null)
                     {
-                        throw new UriTemplateException(string.Format("Invalid value type of variable \"{0}\". Expected: string or IEnumerable<string> or IDictionary<string, string>.", value.GetType()));
+                        stringValue = value.ToString();
                     }
                     else if (dictionaryValue.Count == 0)
                     {

--- a/UrlTemplates/UriTemplate.cs
+++ b/UrlTemplates/UriTemplate.cs
@@ -91,7 +91,28 @@
             return builder.ToString();
         }
 
+        public string Resolve(object variables)
+        {
+            if (variables == null)
+            {
+                throw new ArgumentNullException("variables");
+            }
+
+            var dictionary = new Dictionary<string, object>();
+            foreach (var property in variables.GetType().GetProperties())
+            {
+                if (property.GetGetMethod() != null && property.GetIndexParameters().Length == 0)
+                    dictionary.Add(property.Name, property.GetValue(variables, null));
+            }
+            return Resolve(dictionary);
+        }
+
         public Uri ResolveUri(IDictionary<string, object> variables)
+        {
+            return new Uri(Resolve(variables));
+        }
+
+        public Uri ResolveUri(object variables)
         {
             return new Uri(Resolve(variables));
         }


### PR DESCRIPTION
Overloads for `UriTemplate.Resolve()` and `.ResolveUri()` that build variable dictionaries from object properties

This is useful for anonymous classes, e.g.:

``` csharp
template.Resolve(new {x = "abc"})
```
